### PR TITLE
Refactor cache dropbox

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -6,125 +6,135 @@ use lib\Dropbox;
 use lib\File;
 use lib\Config;
 
-class Cache {
-
+class Cache
+{
     private $cursor_file;
     private $api;
 
-    public function __construct() {
-      $this->dropbox = Dropbox::get_instance();
-      $this->cursor_file = Config::read("storage_object_dir") . "/user.cursor";
-      $this->cursor = $this->read_cursor();
+    public function __construct()
+    {
+        $this->dropbox = Dropbox::get_instance();
+        $this->cursor_file = Config::read("storage_object_dir") . "/user.cursor";
+        $this->cursor = $this->read_cursor();
     }
+
     /**
      * Returns the current "state" of the cache
      * in form of a Dropbox cursor for the delta API
      * (see Dropbox API documentation for more info).
      */
-    private function read_cursor() {
-      $content = File::read($this->cursor_file);
-      if ($content == "") {
-        // An empty file means we have no cursor yet (no chache available).
-        // In this case, the API expects a null object.
-        return Null;
-      }
-      return $content;
-    }
-
-    private function write_cursor($cursor) {
-      File::write($this->cursor_file, $cursor);
-    }
-
-    public function is_up_to_date() {
-      if (!file_exists($this->cursor_file)) {
-        return False;
-      }
-
-      $fmtime = filemtime($this->cursor_file);
-      $currtime = date("U");
-      $delta = $currtime - $fmtime;
-
-      $update_after = Config::read("cache_update_after");
-      if ($delta > $update_after) {
-        return False;
-      }
-      return True;
-    }
-
-    private function remove_cursor() {
-      File::remove($this->cursor_file);
-    }
-
-    public function clear_cache_dir() {
-      $cache_dir = Config::read("cache_dir");
-      // Clear cache
-      if (!isset($cache_dir)) {
-        return;
-      }
-      Directory::rrmdir($cache_dir);
-      mkdir($cache_dir);
-    }
-
-    public function clear() {
-      $this->remove_cursor();
-      $this->clear_cache_dir();
-    }
-
-   /**
-    * Use the Dropbox delta API to cache the gallery.
-    * Every image will be stored inside the cache directory
-    * This increases loading speed significantly.
-    */
-    public function refresh($force_update = False, $purge = False) {
-
-      // Do we need to check for updates?
-      /*if ($this->is_up_to_date() && !$force_update) {
-        return;
-      }*/
-
-      if ($purge) {
-        $this->clear();
-        $this->cursor = $this->read_cursor();
-      }
-
-      // Get changes 
-      if ($this->cursor) {
-		  $changes = $this->dropbox->api->listFolderContinue($this->cursor);
-	  } else {
-		  $changes = $this->dropbox->api->listFolder('/', array("recursive" => true));
-	  }
-
-      do {
-        $entries = $changes->getItems();
-        foreach ($entries as $entry) {
-          $this->write_entry($entry);
+    private function read_cursor()
+    {
+        $content = File::read($this->cursor_file);
+        if ($content == "") {
+            // An empty file means we have no cursor yet (no chache available).
+            // In this case, the API expects a null object.
+            return null;
         }
-        // Refresh cursor
-        $this->cursor = $changes->getCursor();
-
-      // Get all changes until we're done
-      } while ($changes->hasMoreItems());
-
-      // Save current status
-      $this->write_cursor($this->cursor);
+        return $content;
     }
 
-  private function write_entry($entry) {
-    if ($entry instanceof \Kunnu\Dropbox\Models\FolderMetadata) {
-      // Don't write albums, only images.
-      return;
+    private function write_cursor($cursor)
+    {
+        File::write($this->cursor_file, $cursor);
     }
-    $dirname = File::sanitize(dirname($entry->path_display));
-  	$basename = basename($entry->path_display);
-    $local_path = Config::read("cache_dir") . "/" . $dirname . "/" . $basename;
 
-    // Check if dir already exists. Create if not.
-    Directory::rmkdir($local_path);
+    public function is_up_to_date()
+    {
+        if (! file_exists($this->cursor_file)) {
+            return false;
+        }
 
-    $api = Dropbox::get_instance();
-    $outfile = $api->api->download($entry->path_display);
-    File::write($local_path, $outfile->getContents());
-    Image::create_thumbnail($local_path);
-  }
+        $fmtime = filemtime($this->cursor_file);
+        $currtime = date("U");
+        $delta = $currtime - $fmtime;
+
+        $update_after = Config::read("cache_update_after");
+        if ($delta > $update_after) {
+            return false;
+        }
+        return true;
+    }
+
+    private function remove_cursor()
+    {
+        File::remove($this->cursor_file);
+    }
+
+    public function clear_cache_dir()
+    {
+        $cache_dir = Config::read("cache_dir");
+        // Clear cache
+        if (! isset($cache_dir)) {
+            return;
+        }
+        Directory::rrmdir($cache_dir);
+        mkdir($cache_dir);
+    }
+
+    public function clear()
+    {
+        $this->remove_cursor();
+        $this->clear_cache_dir();
+    }
+
+    /**
+     * Use the Dropbox delta API to cache the gallery.
+     * Every image will be stored inside the cache directory
+     * This increases loading speed significantly.
+     */
+    public function refresh($force_update = false, $purge = false)
+    {
+
+        // Do we need to check for updates?
+        /*if ($this->is_up_to_date() && !$force_update) {
+          return;
+        }*/
+
+        if ($purge) {
+            $this->clear();
+            $this->cursor = $this->read_cursor();
+        }
+
+        // Get changes
+        if ($this->cursor) {
+            $changes = $this->dropbox->api->listFolderContinue($this->cursor);
+        } else {
+            $changes = $this->dropbox->api->listFolder('/', array("recursive" => true));
+        }
+
+        do {
+            $entries = $changes->getItems();
+            foreach ($entries as $entry) {
+                $this->write_entry($entry);
+            }
+            // Refresh cursor
+            $this->cursor = $changes->getCursor();
+
+            // Get all changes until we're done
+        } while ($changes->hasMoreItems());
+
+        // Save current status
+        $this->write_cursor($this->cursor);
+    }
+
+    private function write_entry($entry)
+    {
+        if ($entry instanceof \Kunnu\Dropbox\Models\FolderMetadata) {
+            // Don't write albums, only images.
+            return;
+        }
+        $dirname = File::sanitize(dirname($entry->path_display));
+        $basename = basename($entry->path_display);
+        $local_path = Config::read("cache_dir") . "/" . $dirname . "/" . $basename;
+
+        // Check if dir already exists. Create if not.
+        Directory::rmkdir($local_path);
+
+        $api = Dropbox::get_instance();
+        $outfile = $api->api->download($entry->path_display);
+        File::write($local_path, $outfile->getContents());
+        Image::create_thumbnail($local_path);
+    }
 }
 

--- a/lib/Directory.php
+++ b/lib/Directory.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace lib;
-use lib\Config;
 
 // Directory functions
 class Directory {

--- a/lib/Dropbox.php
+++ b/lib/Dropbox.php
@@ -5,38 +5,29 @@ namespace lib;
 use Kunnu\Dropbox\DropboxApp;
 use Kunnu\Dropbox\Dropbox as BaseDropbox;
 
-use lib\Directory;
-use lib\File;
-use lib\Config;
-
-class Dropbox {
-
+class Dropbox
+{
     private static $instance;
-    private $cursor_file;
-    private $cursor;
     public $api;
 
-    private function __construct() {
-      // Check whether to use HTTPS and set the callback URL
-      $protocol = (!empty($_SERVER['HTTPS'])) ? 'https' : 'http';
-      $callback = $protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+    private function __construct()
+    {
+        $identifier = 1; // Fixed identifier for single-user system OR authenticated user ID
 
-      $identifier = 1; // Fixed identifier for single-user system OR authenticated user ID
-
-      $app = new DropboxApp($identifier, Config::read("secret"), Config::read("access_token"));
-      $dropbox = new BaseDropbox($app);
-
-      $this->api = $dropbox;
-
+        $this->api = new BaseDropbox(
+            new DropboxApp($identifier, Config::read('secret'), Config::read('access_token'))
+        );
     }
 
-    public static function get_instance() {
-        if (!isset(self::$instance))
-        {
-            $object = __CLASS__;
-            self::$instance = new $object;
+    /**
+     * @return static
+     */
+    public static function get_instance()
+    {
+        if (! static::$instance) {
+            static::$instance = new static();
         }
+
         return self::$instance;
     }
 }
-


### PR DESCRIPTION
Refactor Cache, Dropbox code

Some more suggestions I didn't want to touch yet since I don't know how much backwards compatibility you want to maintain.

* PSR-2 naming conventions for methods and variables
* avoid public accessor `api` on Dropbox object instead use create wrapper methods for the ones you need on Dropbox class
* Upgrade to minimum PHP 5.6 and use short array syntax
* Change the namespace and add PSR-4 autoloading suggestion could be `Mre\Unicorn`
 